### PR TITLE
Add a CI build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+on: [push, pull_request]
+
+name: CI
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,12 @@ jobs:
           toolchain: stable
 
       - uses: actions-rs/cargo@v1
+        name: Build
         with:
           command: build
 
       - uses: actions-rs/cargo@v1
+        name: Check formatting
         with:
           command: fmt
           args: --all -- --check

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,14 +51,14 @@ fn second_pass(contents: &str, bin: &mut Vec<u8>) -> AsmResult {
 }
 
 /// Filters out comments and empty lines
-pub fn filter_line(line: &str) -> Option<String>{
+pub fn filter_line(line: &str) -> Option<String> {
     let idx = line.find("//");
     let line: &str = match idx {
         Some(x) => line[..x].trim(),
-        None => line.trim()
+        None => line.trim(),
     };
     if line.len() == 0 {
-        return None
+        return None;
     }
     Some(line.to_string())
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,22 +7,20 @@ pub struct Parser {
 }
 
 impl Parser {
-    pub fn new(instruction: String) -> Parser { 
-        Parser {
-            instruction
-        }
+    pub fn new(instruction: String) -> Parser {
+        Parser { instruction }
     }
 
     /// Identifies the instruction's command type and parses attributes
     pub fn parse(&self) -> Option<Command> {
         if let Some(address) = self.a_command() {
-           return Some(Command::A(address))
+            return Some(Command::A(address));
         }
         if let Some(label) = self.l_command() {
-            return Some(Command::L(label))
+            return Some(Command::L(label));
         }
         if let Some((destination, computation, jump)) = self.c_command() {
-            return Some(Command::C(destination, computation, jump))
+            return Some(Command::C(destination, computation, jump));
         }
         None
     }
@@ -30,7 +28,8 @@ impl Parser {
     // TODO: Rename function
     fn a_command(&self) -> Option<Symbol> {
         let a = Regex::new(r"^@(?P<symbol>[a-zA-Z0-9_][a-zA-Z0-9_.$:]{0,}$)").unwrap();
-        a.captures(&self.instruction).map(|cap| Symbol::new(&cap["symbol"]))
+        a.captures(&self.instruction)
+            .map(|cap| Symbol::new(&cap["symbol"]))
     }
 
     // TODO: Rename function
@@ -69,10 +68,11 @@ impl Parser {
     // TODO: Rename function
     pub(crate) fn l_command(&self) -> Option<Symbol> {
         let l = Regex::new(r"^\((?P<symbol>[^)]+)\)$").unwrap();
-        l.captures(&self.instruction).map(|cap| Symbol::new(&cap["symbol"]))
+        l.captures(&self.instruction)
+            .map(|cap| Symbol::new(&cap["symbol"]))
     }
 }
-    
+
 #[derive(Debug, Clone)]
 pub enum Command {
     A(Symbol),
@@ -82,13 +82,13 @@ pub enum Command {
 
 #[derive(Debug, Clone)]
 pub struct Symbol {
-    value: String
+    value: String,
 }
 
 impl Symbol {
     pub fn new(input: &str) -> Symbol {
         Symbol {
-            value: input.to_string()
+            value: input.to_string(),
         }
     }
 }
@@ -101,7 +101,10 @@ pub struct Comp {
 
 impl Comp {
     pub fn new(mnemonic: &str) -> Comp {
-        Comp {mnemonic: mnemonic.to_string(), binary: None}
+        Comp {
+            mnemonic: mnemonic.to_string(),
+            binary: None,
+        }
     }
 }
 
@@ -118,11 +121,11 @@ impl Dest {
             binary: None,
         }
     }
-    
+
     pub fn empty() -> Dest {
         Dest {
             mnemonic: None,
-            binary: None
+            binary: None,
         }
     }
 }
@@ -143,7 +146,7 @@ impl Jump {
     pub fn empty() -> Jump {
         Jump {
             mnemonic: None,
-            binary: None
+            binary: None,
         }
     }
 }

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::fs::File;
 use std::io::prelude::*;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use serde_json;
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -12,7 +12,7 @@ pub struct Table {
     jump: HashMap<String, String>,
     dest: HashMap<String, String>,
     symbol: HashMap<String, i32>,
-    variable: HashMap<String, String>
+    variable: HashMap<String, String>,
 }
 
 impl Table {


### PR DESCRIPTION
This PR adds a minimal GitHub-actions based CI workflow. In order to get the `rustfmt` step to pass, I applied `cargo fmt` globally to this repo. Future additions to the workflow should add automatic `cargo clippy` gatekeeping.

Due to the way GHA work, I don't think these checks run your repo until this PR is merged. In the meantime, you can see what it looks like in my [fork](https://github.com/JayKickliter/my-assembler/compare/master...JayKickliter:jsk/fix-errors#diff-b4aea3e418ccdb71239b96952d9cddb6R20).